### PR TITLE
Describe `--no-quarantine` option to make installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Here is Planetarium's official Homebrew tap.
 
 ~~~~ console
 brew tap planetarium/brew
-brew install planetarium/brew/planet
+brew install planetarium/brew/planet --no-quarantine  # See planetarium/homebrew-brew#41 issue.
 ~~~~
 
 


### PR DESCRIPTION
This pull request ***DOES NOT*** `resolve` #41. It is just for making `planetarium/brew/planet` cask installable.